### PR TITLE
Configure Vault kubernetes pod

### DIFF
--- a/kubernetes/vault/main.tf
+++ b/kubernetes/vault/main.tf
@@ -1,0 +1,66 @@
+terraform {
+  backend "gcs" {
+    bucket  = "noobshack-terraform-state"
+    prefix  = "vault"
+  }
+}
+
+provider "kubernetes" {
+  config_context_cluster = "nsk"
+}
+
+/*
+    Pod
+*/
+
+resource "kubernetes_replication_controller" "vault" {
+  metadata {
+    name      = "${local.service}"
+    labels    = "${var.labels}"
+    namespace = "default"
+  }
+
+  spec {
+    replicas = 1
+
+    selector {
+      app = "${local.service}"
+    }
+
+    template {
+      container {
+        image             = "library/vault:0.9.5"
+        name              = "${local.service}"    // DNS_LABEL for the pod example.cluster.local
+        image_pull_policy = "Always"
+
+        resources {
+          limits {
+            cpu    = "0.5"
+            memory = "512Mi"
+          }
+
+          requests {
+            cpu    = "250m"
+            memory = "50Mi"
+          }
+        }
+      }
+    }
+  }
+}
+
+/*
+    Config Map
+*/
+
+resource "kubernetes_config_map" "vault" {
+  metadata {
+    name      = "${local.service}"
+    labels    = "${var.labels}"
+    namespace = "default"
+  }
+
+  data {
+    foo = "bar"
+  }
+}

--- a/kubernetes/vault/variables.tf
+++ b/kubernetes/vault/variables.tf
@@ -1,0 +1,11 @@
+variable "labels" {
+  type = "map"
+
+  default = {
+    app = "vault"
+  }
+}
+
+locals {
+  service = "vault"
+}


### PR DESCRIPTION
Create a replication controller for the HashiCorp vault service.

- Pin version to 0.9.5

TODO:
- Pass in config file.
- Setup DNS
- Generate secrets.